### PR TITLE
Hcs axes fix

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -463,7 +463,7 @@ class Plate(Spec):
         stitched full-resolution images.
         """
         self.plate_data = self.lookup("plate", {})
-        LOGGER.info("plate_data", self.plate_data)
+        LOGGER.info("plate_data: %s", self.plate_data)
         self.rows = self.plate_data.get("rows")
         self.columns = self.plate_data.get("columns")
         self.first_field = "0"
@@ -484,7 +484,7 @@ class Plate(Spec):
             raise Exception("could not find first well")
         self.numpy_type = well_spec.numpy_type
 
-        LOGGER.debug("img_pyramid_shapes", well_spec.img_pyramid_shapes)
+        LOGGER.debug(f"img_pyramid_shapes: {well_spec.img_pyramid_shapes}")
 
         self.axes = well_spec.img_metadata["axes"]
         size_y = well_spec.img_shape[len(self.axes) - 2]
@@ -505,7 +505,7 @@ class Plate(Spec):
             if longest_side <= TARGET_SIZE:
                 break
 
-        LOGGER.debug("target_level", target_level)
+        LOGGER.debug(f"target_level: {target_level}")
 
         pyramid = []
 
@@ -535,11 +535,13 @@ class Plate(Spec):
         )
 
     def get_stitched_grid(self, level: int, tile_shape: tuple) -> da.core.Array:
+        LOGGER.debug(f"get_stitched_grid() level: {level}, tile_shape: {tile_shape}")
+
         def get_tile(tile_name: str) -> np.ndarray:
             """tile_name is 'level,z,c,t,row,col'"""
             row, col = (int(n) for n in tile_name.split(","))
             path = self.get_tile_path(level, row, col)
-            LOGGER.debug(f"LOADING tile... {path}")
+            LOGGER.debug(f"LOADING tile... {path} with shape: {tile_shape}")
 
             try:
                 data = self.zarr.load(path)

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -55,7 +55,7 @@ class Node:
             self.specs.append(PlateLabels(self))
         elif Plate.matches(zarr):
             self.specs.append(Plate(self))
-            self.add(zarr, plate_labels=True)
+            # self.add(zarr, plate_labels=True)
         if Well.matches(zarr):
             self.specs.append(Well(self))
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -4,7 +4,7 @@ from numpy import zeros
 
 from ome_zarr.data import create_zarr
 from ome_zarr.io import parse_url
-from ome_zarr.reader import Node, Plate, PlateLabels, Reader
+from ome_zarr.reader import Node, Plate, Reader
 from ome_zarr.writer import write_image, write_plate_metadata, write_well_metadata
 
 
@@ -50,11 +50,12 @@ class TestHCSReader:
 
         reader = Reader(parse_url(str(self.path)))
         nodes = list(reader())
-        assert len(nodes) == 2
+        # currently reading plate labels disabled. Only 1 node
+        assert len(nodes) == 1
         assert len(nodes[0].specs) == 1
         assert isinstance(nodes[0].specs[0], Plate)
-        assert len(nodes[1].specs) == 1
-        assert isinstance(nodes[1].specs[0], PlateLabels)
+        # assert len(nodes[1].specs) == 1
+        # assert isinstance(nodes[1].specs[0], PlateLabels)
 
     def test_multiwells_plate(self):
         row_names = ["A", "B", "C"]
@@ -72,8 +73,9 @@ class TestHCSReader:
 
         reader = Reader(parse_url(str(self.path)))
         nodes = list(reader())
-        assert len(nodes) == 2
+        # currently reading plate labels disabled. Only 1 node
+        assert len(nodes) == 1
         assert len(nodes[0].specs) == 1
         assert isinstance(nodes[0].specs[0], Plate)
-        assert len(nodes[1].specs) == 1
-        assert isinstance(nodes[1].specs[0], PlateLabels)
+        # assert len(nodes[1].specs) == 1
+        # assert isinstance(nodes[1].specs[0], PlateLabels)


### PR DESCRIPTION
Just by avoiding Plate labels (and fixing a few logging statements) this allows me to view a 3-channel small plate on napari locally.

Works with local 3-channel single Z/T plate and with 
```napari https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr```

![Screenshot 2022-01-17 at 13 41 45](https://user-images.githubusercontent.com/900055/149779548-4cc66166-1bcd-4d37-8c45-ee036521b4cf.png)

